### PR TITLE
ブランチ：08 photo upload and page flip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 
 .DS_Store
 /vendor/bundle
+
+/public/uploads/

--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ end
 gem "tailwindcss-rails", "~> 3.3.1"
 gem "devise"
 gem "devise-i18n"
+gem "carrierwave"
+gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.1.2)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -114,10 +121,21 @@ GEM
     erubi (1.13.1)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.8.0)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -142,6 +160,9 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.2.0)
+      benchmark
+      logger
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -268,6 +289,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.3)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.32.0)
@@ -284,6 +308,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.3.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
@@ -337,12 +362,14 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  carrierwave
   debug
   devise
   devise-i18n
   faker
   jbuilder
   jsbundling-rails
+  mini_magick
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/assets/stylesheets/page_flip.css
+++ b/app/assets/stylesheets/page_flip.css
@@ -1,0 +1,5 @@
+.page {
+  width: 100%;
+  height: 100%;
+  background: whitesmoke;
+}

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,7 +10,7 @@ class AlbumsController < ApplicationController
   def create
     @album = current_user.albums.new(album_params)
     if @album.save
-      redirect_to albums_path, status: :see_other, notice: "アルバムを作成しました"
+      redirect_to new_album_photo_path(@album), status: :see_other, notice: "アルバムを作成しました"
     else
     flash.now[:alert] = "アルバムを作成できませんでした"
     render :new, status: :unprocessable_entity # 作成失敗したエラーメッセージを表示するのに必要

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -19,6 +19,7 @@ class AlbumsController < ApplicationController
 
   def show
     @album = current_user.albums.find(params[:id])
+    @photos = @album.photos
   end
 
   private

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -12,7 +12,7 @@ class AlbumsController < ApplicationController
     if @album.save
       redirect_to albums_path, status: :see_other, notice: "アルバムを作成しました"
     else
-      flash.now[:alert] = "アルバムを作成できませんでした"
+    flash.now[:alert] = "アルバムを作成できませんでした"
     render :new, status: :unprocessable_entity # 作成失敗したエラーメッセージを表示するのに必要
     end
   end

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -17,6 +17,10 @@ class AlbumsController < ApplicationController
     end
   end
 
+  def show
+    @album = current_user.albums.find(params[:id])
+  end
+
   private
 
   def album_params

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,24 +1,30 @@
 class PhotosController < ApplicationController
   def new
-    @album = current_user.album(params[:album_id])
-    @photo = @album.photos.new
+    @album = current_user.albums.find(params[:album_id])
+    @photo = current_user.photos.new
   end
 
   def create
-    @album = current_user.album(params[:album_id])
-    @photo = @album.photos.builds(photo_params)
+    @album = current_user.albums.find(params[:album_id])
+    @photo = current_user.photos.new(photo_params)
+    @photo.album = @album # 関連を設定
 
     if @photo.save
-      redirect_to album_path(params[:album_id]), notice = "画像を保存しました"
+      redirect_to album_path(@album), status: :see_other, notice: "画像を保存しました"
     else
       flash.now[:alert] = "画像を保存できませんでした"
       render :new, status: :unprocessable_entity
     end
   end
 
+  def show
+    @album = current_user.albums.find(params[:album_id])
+    @photos = @album.photos
+  end
+
   private
 
   def photo_params
-    params.require(:photo).permit(:comment, { images: [] } )
+    params.require(:photo).permit(:comment, { images: [] }, :image_cache )
   end
 end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -6,16 +6,23 @@ class PhotosController < ApplicationController
 
   def create
     @album = current_user.albums.find(params[:album_id])
-    @photo = current_user.photos.new(photo_params)
-    @photo.album = @album # 関連を設定
-
-    if @photo.save
-      redirect_to album_path(@album), status: :see_other, notice: "画像を保存しました"
+    uploaded_images = params[:images] || []
+    comments = params[:comments] || []
+    if uploaded_images.any?
+      uploaded_images.each_with_index do |image, i|
+        comment = comments[i] || "" # 画像に対応するコメントを取り出す。もしコメントが送られていなければ、空の文字列""を使う
+        photo = current_user.photos.new(comment: comment, album: @album) # photoの新しいデータを作る。コメントを設定してアルバムと紐付ける。
+        photo.images = [image] # CarrierWaveが画像を配列で受け取れるように、画像を配列の形にする
+        photo.save
+      end
+  
+      redirect_to album_path(@album), notice: "画像を保存しました", status: :see_other
     else
-      flash.now[:alert] = "画像を保存できませんでした"
+      flash.now[:alert] = "画像が選択されていません"
       render :new, status: :unprocessable_entity
     end
   end
+  
 
   def show
     @album = current_user.albums.find(params[:album_id])

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -12,17 +12,17 @@ class PhotosController < ApplicationController
       uploaded_images.each_with_index do |image, i|
         comment = comments[i] || "" # 画像に対応するコメントを取り出す。もしコメントが送られていなければ、空の文字列""を使う
         photo = current_user.photos.new(comment: comment, album: @album) # photoの新しいデータを作る。コメントを設定してアルバムと紐付ける。
-        photo.images = [image] # CarrierWaveが画像を配列で受け取れるように、画像を配列の形にする
+        photo.images = [ image ] # CarrierWaveが画像を配列で受け取れるように、画像を配列の形にする
         photo.save
       end
-  
+
       redirect_to album_path(@album), notice: "画像を保存しました", status: :see_other
     else
       flash.now[:alert] = "画像が選択されていません"
       render :new, status: :unprocessable_entity
     end
   end
-  
+
 
   def show
     @album = current_user.albums.find(params[:album_id])
@@ -32,6 +32,6 @@ class PhotosController < ApplicationController
   private
 
   def photo_params
-    params.require(:photo).permit(:comment, { images: [] }, :image_cache )
+    params.require(:photo).permit(:comment, { images: [] }, :image_cache)
   end
 end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,0 +1,24 @@
+class PhotosController < ApplicationController
+  def new
+    @album = current_user.album(params[:album_id])
+    @photo = @album.photos.new
+  end
+
+  def create
+    @album = current_user.album(params[:album_id])
+    @photo = @album.photos.builds(photo_params)
+
+    if @photo.save
+      redirect_to album_path(params[:album_id]), notice = "画像を保存しました"
+    else
+      flash.now[:alert] = "画像を保存できませんでした"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def photo_params
+    params.require(:photo).permit(:comment, { images: [] } )
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,18 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-import { PageFlip } from "page-flip";
-
-// page-flip
-document.addEventListener("DOMContentLoaded", () => {
-  const elm = document.getElementById("book");
-
-  if (elm) {
-    const pageFlip = new PageFlip(document.getElementById('book'), {
-      width: 400,
-      height: 600,
-    });
-
-    pageFlip.loadFromHTML(document.querySelectorAll('.my-page'));
-  }
-});
+import "./pageflip"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -16,4 +16,3 @@ document.addEventListener("DOMContentLoaded", () => {
     pageFlip.loadFromHTML(document.querySelectorAll('.my-page'));
   }
 });
-

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,6 +3,7 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import { PageFlip } from "page-flip";
 
+// page-flip
 document.addEventListener("DOMContentLoaded", () => {
   const elm = document.getElementById("book");
 
@@ -15,3 +16,4 @@ document.addEventListener("DOMContentLoaded", () => {
     pageFlip.loadFromHTML(document.querySelectorAll('.my-page'));
   }
 });
+

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,17 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import { PageFlip } from "page-flip";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const elm = document.getElementById("book");
+
+  if (elm) {
+    const pageFlip = new PageFlip(document.getElementById('book'), {
+      width: 400,
+      height: 600,
+    });
+
+    pageFlip.loadFromHTML(document.querySelectorAll('.my-page'));
+  }
+});

--- a/app/javascript/pageflip.js
+++ b/app/javascript/pageflip.js
@@ -1,0 +1,14 @@
+import { PageFlip } from "page-flip";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const elm = document.getElementById("book");
+
+  if (elm) {
+    const pageFlip = new PageFlip(document.getElementById('book'), {
+      width: 400,
+      height: 600,
+    });
+
+    pageFlip.loadFromHTML(document.querySelectorAll('.my-page'));
+  }
+});

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -3,5 +3,5 @@ class Album < ApplicationRecord
   validates :description, presence: true, length: { maximum: 65_535 }
 
   belongs_to :user
-  has_many :album_photos, dependent: :destroy
+  has_many :photos, dependent: :destroy
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,0 +1,2 @@
+class Photo < ApplicationRecord
+end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,2 +1,4 @@
 class Photo < ApplicationRecord
+  validates :text, length: { maximum: 65_535 }
+  mount_uploaders :images, ImageUploader
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,4 +1,5 @@
 class Photo < ApplicationRecord
   validates :text, length: { maximum: 65_535 }
+  belongs_to :album
   mount_uploaders :images, ImageUploader
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,5 +1,5 @@
 class Photo < ApplicationRecord
-  validates :text, length: { maximum: 65_535 }
+  validates :comment, length: { maximum: 65_535 }
   belongs_to :user
   belongs_to :album
   mount_uploaders :images, ImageUploader

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,5 +1,6 @@
 class Photo < ApplicationRecord
   validates :text, length: { maximum: 65_535 }
+  belongs_to :user
   belongs_to :album
   mount_uploaders :images, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   has_many :albums, dependent: :destroy
+  has_many :photos, dependent: :destroy
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,9 +36,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick, MiniMagick, or Vips support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+  # include CarrierWave::Vips
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -37,7 +37,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg gif png]
   end
 
   # Override the filename of the uploaded files:

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,10 +1,12 @@
-<% if @album.photos.present? %>
-  <% @album.photos.each do |photo| %>
-    <% if photo.images.present? %>
-      <% photo.images.each do |image| %>
-        <%= image_tag image.to_s%>
+<h2><%= @album.title %></h2>
+
+<% if @photos.present? %>
+  <% @photos.each do |photo| %>
+    <% photo.images.each do |image| %>
+      <div class="mb-4">
+        <%= image_tag image.url, class: "w-48 h-48 object-cover border rounded" %>
         <p><%= photo.comment %></p>
-      <% end %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,12 +1,24 @@
-<h2><%= @album.title %></h2>
+<div class="w-full flex flex-col items-center">
+  <div class="flex justify-between items-center px-4 py-2 bg-gray-100 border-b">
+    <div><%= @album.title %></div>
+  </div>
+  <div>
+    <%= link_to "画像の追加" %>
+    <%= link_to "画像の編集" %>
+  </div>
 
-<% if @photos.present? %>
-  <% @photos.each do |photo| %>
-    <% photo.images.each do |image| %>
-      <div class="mb-4">
-        <%= image_tag image.url, class: "w-48 h-48 object-cover border rounded" %>
-        <p><%= photo.comment %></p>
-      </div>
+  <div id="book">
+    <% if @photos.present? %>
+      <% @photos.each do |photo| %>
+        <% if photo.images.present? %>
+          <% photo.images.each do |image| %>
+            <div class="my-page">
+              <%= image_tag image.url %>
+              <p class="photo-comment"><%= photo.comment %></p>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,0 +1,10 @@
+<% if @album.photos.present? %>
+  <% @album.photos.each do |photo| %>
+    <% if photo.images.present? %>
+      <% photo.images.each do |image| %>
+        <%= image_tag image.to_s%>
+        <p><%= photo.comment %></p>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,17 +1,19 @@
-<%= form_with model: [@album, Photo.new], local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
-  <!-- ファイル選択 -->
-  <div>
-    <%= f.label :images, t('photos.new.choice'), class: "block mb-2 text-lg font-medium text-gray-700" %>
-    <%= f.file_field :images, multiple: true, accept: 'image/*', class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
-  </div>
-
-  <!-- コメント入力 -->
-  <div>
-    <%= f.label :comment, "コメント", class: "block mb-2 text-lg font-medium text-gray-700" %>
-    <%= f.text_field :comment, class: "w-full border border-gray-300 rounded px-3 py-2" %>
-  </div>
-
-  <div class="flex justify-center">
-    <%= f.submit t('photos.new.upload'), class: "w-1/2 bg-button hover:bg-change text-white font-semibold py-2 rounded-lg text-lg" %>
-  </div>
-<% end %>
+<div class="w-full flex flex-col items-center">
+  <%= form_with model: [@album, Photo.new], local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
+    <!-- ファイル選択 -->
+    <div>
+      <%= f.label :images, class: "block mb-2 text-lg font-medium text-gray-700" %>
+      <%= f.file_field :images, multiple: true, accept: 'image/*', class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+    </div>
+  
+    <!-- コメント入力 -->
+    <div>
+      <%= f.label :comment, class: "block mb-2 text-lg font-medium text-gray-700" %>
+      <%= f.text_field :comment, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  
+    <div class="flex justify-center">
+      <%= f.submit t('defaults.upload'), class: "w-1/2 bg-button hover:bg-change text-white font-semibold py-2 rounded-lg text-lg" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: [@album, Photo.new], local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
+  <!-- ファイル選択 -->
+  <div>
+    <%= f.label :images, t('photos.new.choice'), class: "block mb-2 text-lg font-medium text-gray-700" %>
+    <%= f.file_field :images, multiple: true, accept: 'image/*', class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+  </div>
+
+  <!-- コメント入力 -->
+  <div>
+    <%= f.label :comment, "コメント", class: "block mb-2 text-lg font-medium text-gray-700" %>
+    <%= f.text_field :comment, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+  </div>
+
+  <div class="flex justify-center">
+    <%= f.submit t('photos.new.upload'), class: "w-1/2 bg-button hover:bg-change text-white font-semibold py-2 rounded-lg text-lg" %>
+  </div>
+<% end %>

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,7 +1,6 @@
 <div class="w-full flex flex-col items-center">
-  <%= form_with model: [@album, Photo.new], local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
-
-    <% if @photo.errors.any? %>
+  <%= form_with url: album_photos_path(@album), local: true, multipart: true do |f| %>
+    <% if @photo && @photo.errors.any? %>
       <div class="text-red-500 mb-4">
         <ul>
           <% @photo.errors.full_messages.each do |msg| %>
@@ -11,21 +10,47 @@
       </div>
     <% end %>
 
-    <!-- ファイル選択 -->
-    <div>
-      <%= f.label :images, class: "block mb-2 text-lg font-medium text-gray-700" %>
-      <%= f.file_field :images, multiple: true, accept: 'image/*', class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
-      <%= f.hidden_field :images_cache %>
+    <!-- 複数画像を選択 -->
+    <div class="mb-4 w-full">
+      <label class="block font-bold">画像を選択（複数）</label>
+      <input type="file" name="images[]" id="image-input" multiple accept="image/*" class="border p-2 w-full" />
     </div>
-  
-    <!-- コメント入力 -->
-    <div>
-      <%= f.label :comment, class: "block mb-2 text-lg font-medium text-gray-700" %>
-      <%= f.text_field :comment, class: "w-full border border-gray-300 rounded px-3 py-2" %>
-    </div>
-  
-    <div class="flex justify-center">
-      <%= f.submit t('defaults.upload'), class: "w-1/2 bg-button hover:bg-change text-white font-semibold py-2 rounded-lg text-lg" %>
-    </div>
+
+    <!-- 画像ごとのプレビューとコメント入力欄 -->
+    <div id="preview-container" class="space-y-4 w-full"></div>
+
+    <%= f.submit "アップロード", class: "mt-4 bg-blue-500 text-white px-4 py-2 rounded" %>
   <% end %>
 </div>
+
+<script>
+document.getElementById("image-input").addEventListener("change", function(event) {
+  const previewContainer = document.getElementById("preview-container");
+  previewContainer.innerHTML = "";
+
+  const files = Array.from(event.target.files);
+
+  files.forEach((file, index) => {
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      const wrapper = document.createElement("div");
+      wrapper.className = "flex items-center space-x-4";
+
+      const image = document.createElement("img");
+      image.src = e.target.result;
+      image.className = "w-32 h-32 object-cover border rounded";
+
+      const comment = document.createElement("input");
+      comment.type = "text";
+      comment.name = "comments[]";
+      comment.placeholder = "コメントを入力";
+      comment.className = "flex-1 border px-2 py-1 rounded";
+
+      wrapper.appendChild(image);
+      wrapper.appendChild(comment);
+      previewContainer.appendChild(wrapper);
+    };
+    reader.readAsDataURL(file);
+  });
+});
+</script>

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,9 +1,21 @@
 <div class="w-full flex flex-col items-center">
   <%= form_with model: [@album, Photo.new], local: true, html: { multipart: true }, class: "space-y-6" do |f| %>
+
+    <% if @photo.errors.any? %>
+      <div class="text-red-500 mb-4">
+        <ul>
+          <% @photo.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <!-- ファイル選択 -->
     <div>
       <%= f.label :images, class: "block mb-2 text-lg font-medium text-gray-700" %>
       <%= f.file_field :images, multiple: true, accept: 'image/*', class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      <%= f.hidden_field :images_cache %>
     </div>
   
     <!-- コメント入力 -->

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,3 +10,9 @@ ja:
       photo:
         images: 画像（複数アップロード可）
         comment: コメント
+    errors:
+      models:
+        photo:
+          attributes:
+            album:
+              required: "を指定してください"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,7 +2,11 @@ ja:
   activerecord:
     models:
       album: アルバム
+      photo: フォト
     attributes:
       album:
         title: タイトル
         description: 説明
+      photo:
+        images: 画像（複数アップロード可）
+        comment: コメント

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,9 +4,12 @@ ja:
     edit: 編集
     show: 詳細
     delete: 削除
+    upload: アップロード
   label:
     title: タイトル
     description: 説明
+    images: 画像（複数アップロード可）
+    comment: コメント
   header:
     albums:
       index: アルバム一覧
@@ -18,6 +21,8 @@ ja:
   albums:
     new:
       title: アルバム作成
+  photos:
+
   errors:
     messages:
       blank: を入力してください。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "memories#top"
 
-  resources :albums, only: %i[index new create]
+  resources :albums, only: %i[index new create] do
+    resources :photos, only: %i[new create]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "memories#top"
 
-  resources :albums, only: %i[index new create] do
+  resources :albums, only: %i[index new create show] do
     resources :photos, only: %i[new create]
   end
 end

--- a/db/migrate/20250516135852_create_photos.rb
+++ b/db/migrate/20250516135852_create_photos.rb
@@ -3,6 +3,7 @@ class CreatePhotos < ActiveRecord::Migration[7.2]
     create_table :photos do |t|
       t.json :images
       t.text :comment
+      t.references :user, foreign_key: true
       t.references :album, foreign_key: true
       t.timestamps
     end

--- a/db/migrate/20250516135852_create_photos.rb
+++ b/db/migrate/20250516135852_create_photos.rb
@@ -1,0 +1,10 @@
+class CreatePhotos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :photos do |t|
+      t.json :images
+      t.text :comment
+      t.references :album, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_16_031247) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_16_135852) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_16_031247) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_albums_on_user_id"
+  end
+
+  create_table "photos", force: :cascade do |t|
+    t.json "images"
+    t.text "comment"
+    t.bigint "album_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["album_id"], name: "index_photos_on_album_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -37,4 +46,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_16_031247) do
   end
 
   add_foreign_key "albums", "users"
+  add_foreign_key "photos", "albums"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,10 +26,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_16_135852) do
   create_table "photos", force: :cascade do |t|
     t.json "images"
     t.text "comment"
+    t.bigint "user_id"
     t.bigint "album_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["album_id"], name: "index_photos_on_album_id"
+    t.index ["user_id"], name: "index_photos_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -47,4 +49,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_16_135852) do
 
   add_foreign_key "albums", "users"
   add_foreign_key "photos", "albums"
+  add_foreign_key "photos", "users"
 end

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@hotwired/turbo-rails": "^8.0.13"
+    "@hotwired/turbo-rails": "^8.0.13",
+    "page-flip": "^2.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,3 +180,8 @@ esbuild@^0.25.4:
     "@esbuild/win32-arm64" "0.25.4"
     "@esbuild/win32-ia32" "0.25.4"
     "@esbuild/win32-x64" "0.25.4"
+
+page-flip@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/page-flip/-/page-flip-2.0.7.tgz#b6eaf9dac78fd1dceeb7cb4d0e2eeb203591ea1e"
+  integrity sha512-96lQFUUz7r/LZzEUZJ3yBIMEKU9+m8HMFDzTvTdD6P7Ag/wXINjp9n0W7b4wanwnDbQETo4uNUoL3zMqpFxwGA==


### PR DESCRIPTION
## 概要
- 画像アップロード画面追加
- アルバムとしてページ上に画像とコメント表示

## 詳細
- CarrierWaveで複数画像アップロード機能追加しました
- Page Flip導入し(docker compose exec web yarn add page-flipコマンド実行)アップロードした画像とそれに紐づいたコメントをページ上に表示させました

- アップロード画面
<img width="1470" alt="スクリーンショット 2025-05-18 0 55 26" src="https://github.com/user-attachments/assets/31b1488c-4320-49f7-9457-88099892eae8" />

- アルバム詳細画面
<img width="1470" alt="スクリーンショット 2025-05-18 0 57 12" src="https://github.com/user-attachments/assets/fa248a8b-c038-4e64-9322-2c74783cf5a8" />

## 補足
- アルバム詳細画面のレイアウトは後ほど調整

Closes #23 
Closes #24 