### PR TITLE
ブランチ：19 password reset dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ group :development, :test do
   gem "rubocop"
   gem "faker"
   gem "dotenv-rails"
+
+  gem "letter_opener_web", "2.0.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -171,6 +173,17 @@ GEM
       railties (>= 6.0.0)
     json (2.12.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -399,6 +412,7 @@ DEPENDENCIES
   fog-aws
   jbuilder
   jsbundling-rails
+  letter_opener_web (= 2.0.0)
   mini_magick
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/views/memories/top.html.erb
+++ b/app/views/memories/top.html.erb
@@ -6,5 +6,6 @@
   <hr class="border-t border-white pb-2 w-full mb-16"><!-- 白線 -->
   <p class="text-white text-xl md:text-2xl mt-4 mb-20 text-center">大切な思い出をアルバムに。</p>
   <%= link_to t('devise.sessions.new.sign_in'), new_user_session_path, class: "bg-white text-black px-6 py-2 rounded-lg text-md md:text-lg font-medium hover:bg-gray-200 mb-8" %>
-  <%= link_to t('devise.registrations.new.sign_up'), new_user_registration_path, class: "text-white underline text-md md:text-lg text-center" %>
+  <%= link_to t('devise.passwords.new.forgot_your_password'), new_user_password_path, class: "text-white hover:underline text-md md:text-lg text-center mb-4" %>
+  <%= link_to t('devise.registrations.new.sign_up'), new_user_registration_path, class: "text-white hover:underline text-md md:text-lg text-center" %>
 </div>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,10 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('devise.mailer.reset_password_instructions.greeting', recipient: @resource.email) %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('devise.mailer.reset_password_instructions.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('devise.mailer.reset_password_instructions.instruction_2') %></p>
+
+<p><%= t('devise.mailer.reset_password_instructions.instruction_3') %></p>
+

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,28 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+<div class="w-full flex flex-col items-center">
+  <div class="font-semibold text-2xl md:text-3xl mb-10 text-gray-800">
+    <%= t('devise.passwords.edit.title') %>
   </div>
+  
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
+  
+    <div class="mb-12 flex items-center">
+      <%= f.label :password, class: "w-full text-gray-700 text-lg md:text-xl"  %>
+      <% if @minimum_password_length %>
+        <em class= "text-gray-700 text-lg md:text-xl">(<%= @minimum_password_length %><%= t('devise.passwords.edit.characters_minimum') %>)</em>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password" , class: "w-full  border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+    </div>
+  
+    <div class="mb-12 flex items-center">
+      <%= f.label :password_confirmation, class: "w-full text-gray-700 text-lg md:text-xl"  %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+    </div>
+  
+    <div class="mt-6 flex justify-center">
+      <%= f.submit t('devise.passwords.edit.change_my_password'), class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
+    </div>
+  <% end %>
+</div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="w-full flex flex-col items-center">
+  <div class="font-semibold text-2xl md:text-3xl mb-10 text-gray-800">
+    <%= t('devise.passwords.new.title') %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+  
+  <div class="rounded-lg w-full max-w-xl p-8">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+    
+      <div class="mb-12 flex items-center">
+        <%= f.label :email, class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.email_field :email, autofocus: true, class: "w-full mr-20 border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <div class="mt-6 flex justify-center">
+        <%= f.submit t('devise.passwords.new.send_me'), class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
+      </div>
+    <% end %>
+    </div>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,13 +35,15 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost:3000", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
 
   # Unlike controllers, the mailer instance doesn't have any context about the
   # incoming request so you'll need to provide the :host parameter yourself.
-  config.action_mailer.default_url_options = { host: "www.example.com" }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
 
   # Unlike controllers, the mailer instance doesn't have any context about the
   # incoming request so you'll need to provide the :host parameter yourself.
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -83,7 +83,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードをお忘れの方はこちら
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -78,6 +78,8 @@ ja:
       success: "%{kind} アカウントによる認証に成功しました。"
     passwords:
       edit:
+        title: パスワード再設定
+        characters_minimum: 文字以上で設定してください
         change_my_password: パスワードを変更する
         change_your_password: パスワードを変更
         confirm_new_password: 確認用新しいパスワード

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -2,22 +2,22 @@ ja:
   activerecord:
     attributes:
       user:
-        name: 名前
+        name: 名前：
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻
         created_at: 作成日
-        current_password: 現在のパスワード
+        current_password: 現在のパスワード：
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: メールアドレス
+        email: メールアドレス：
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
-        password: パスワード
-        password_confirmation: パスワード（確認用）
+        password: パスワード：
+        password_confirmation: パスワード（確認用）：
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻
@@ -83,7 +83,9 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
+        title: パスワード再設定用リンクの送信
         forgot_your_password: パスワードをお忘れの方はこちら
+        send_me: 送信
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions",
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,8 @@ Rails.application.routes.draw do
     get "edit_photos", to: "photos#edit_multiple", as: :edit_photos
     patch "update_photos", to: "photos#update_multiple", as: :update_photos
   end
+  # letter_opener_webの設定
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end


### PR DESCRIPTION
## 概要
開発環境で、パスワード再設定用のルーティング〜レイアウト追加

## 詳細
- gem 'letter_opener_web'を使用して、deviseでのパスワード再設定のレイアウト追加

- TOP画面

<img width="1470" alt="スクリーンショット 2025-05-28 7 43 52" src="https://github.com/user-attachments/assets/6ab9b72a-df0f-467d-97d0-b863ee6208c2" />


- パスワード再設定用リンク送信画面

<img width="1470" alt="スクリーンショット 2025-05-28 7 44 50" src="https://github.com/user-attachments/assets/dfcbc841-24b4-4f57-997c-6541edea0fc3" />


- パスワード再設定用リンクを添付したメール画面

<img width="1470" alt="スクリーンショット 2025-05-28 8 29 37" src="https://github.com/user-attachments/assets/35a75bf0-fb23-4b1a-91fe-e2059bcc9885" />

- パスワード変更画面

<img width="1470" alt="スクリーンショット 2025-05-28 8 28 35" src="https://github.com/user-attachments/assets/dfb657c0-c373-4fd0-b307-a03026d37d73" />

Closes #54 
Closes #55 