### PR TITLE
ブランチ：20 password reset production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  # パスワードリセットのメールをgmailで送る設定
   config.action_mailer.default_url_options = { host: "localhost:3000" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
     address: "smtp.gmail.com",
     domain: "gmail.com",
     port: 587,
-    user_name: ENV["MAILER_SENDER"], 
-    password: ENV["MAILER_PASSWORD"], 
+    user_name: ENV['MAILER_SENDER'],
+    password: ENV['MAILER_PASSWORD'],
     authentication: :login
   }
   config.action_mailer.perform_deliveries = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,8 +48,8 @@ Rails.application.configure do
     address: "smtp.gmail.com",
     domain: "gmail.com",
     port: 587,
-    user_name: ENV['MAILER_SENDER'],
-    password: ENV['MAILER_PASSWORD'],
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
     authentication: :login
   }
   config.action_mailer.perform_deliveries = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,8 +41,16 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost:3000", port: 3000 }
-  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.default_url_options = { host: "localhost:3000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: "gmail.com",
+    port: 587,
+    user_name: ENV["MAILER_SENDER"], 
+    password: ENV["MAILER_PASSWORD"], 
+    authentication: :login
+  }
   config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,9 +78,20 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  # パスワードリセットのメールをgmailで送る設定
+  config.action_mailer.default_url_options = { :host => 'https://memory-20250515.onrender.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: 'gmail.com',
+    port: 587,
+    user_name: ENV['MAILER_SENDER'],
+    password: ENV['MAILER_PASSWORD'],
+    authentication: :login
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,14 +79,14 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # パスワードリセットのメールをgmailで送る設定
-  config.action_mailer.default_url_options = { :host => 'https://memory-20250515.onrender.com' }
+  config.action_mailer.default_url_options = { host: "https://memory-20250515.onrender.com" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",
-    domain: 'gmail.com',
+    domain: "gmail.com",
     port: 587,
-    user_name: ENV['MAILER_SENDER'],
-    password: ENV['MAILER_PASSWORD'],
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
     authentication: :login
   }
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## 概要
開発・本番環境でパスワードリセットのメールをgmailで送る設定を追加

## 動作確認
TOP画面の「パスワードをお忘れの方はこちら」のリンクから、パスワードリセット用のメールを受信し、パスワードリセット用リンクから正常にパスワードの変更ができるか確認

Closes #48 