### PR TITLE
ブランチ：26 email change confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -16,7 +16,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # The path used after resending confirmation instructions.
   # def after_resending_confirmation_instructions_path_for(resource_name)
@@ -24,7 +24,12 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+  # email変更時、認証メールのリンククリック後の遷移先を指定
+  def after_confirmation_path_for(resource_name, resource)
+    if user_signed_in?
+      edit_user_registration_path
+    else
+      new_session_path(resource_name)
+    end
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -26,6 +26,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if resource.active_for_authentication?
       set_flash_message! :notice, :signed_up
       sign_up(resource_name, resource)
+
+      UserMailer.welcome_email(resource).deliver_later # ここでWelcomeメール送信
+
       respond_with resource, location: after_sign_up_path_for(resource)
     else
       set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -78,6 +78,11 @@ end
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 
+  # アカウント情報を編集した後の遷移先を指定
+  def after_update_path_for(resource)
+    albums_path
+  end
+
   # The path used after sign up.
   # def after_sign_up_path_for(resource)
   #   super(resource)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       set_flash_message! :notice, :signed_up
       sign_up(resource_name, resource)
 
-      UserMailer.welcome_email(resource).deliver_later # ここでWelcomeメール送信
+      UserMailer.welcome_email(resource).deliver_now # ここでWelcomeメール送信(非同期送信ならdeliver_later(ActiveJob + Sidekiqなどを使う場合）)
 
       respond_with resource, location: after_sign_up_path_for(resource)
     else

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,6 +14,31 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  # 会員登録時のメール認証スキップするためオーバーライド
+  def create
+  build_resource(sign_up_params)
+
+  resource.skip_confirmation! # ここ追加（会員登録時のメール認証スキップ）
+  resource.save
+
+  yield resource if block_given?
+  if resource.persisted?
+    if resource.active_for_authentication?
+      set_flash_message! :notice, :signed_up
+      sign_up(resource_name, resource)
+      respond_with resource, location: after_sign_up_path_for(resource)
+    else
+      set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+      expire_data_after_sign_in!
+      respond_with resource, location: after_inactive_sign_up_path_for(resource)
+    end
+  else
+    clean_up_passwords resource
+    set_minimum_password_length
+    respond_with resource
+  end
+end
+
   # GET /resource/edit
   # def edit
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -80,7 +80,7 @@ end
 
   # アカウント情報を編集した後の遷移先を指定
   def after_update_path_for(resource)
-    albums_path
+    edit_user_registration_path
   end
 
   # The path used after sign up.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,2 @@
+class UserMailer < ApplicationMailer
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,2 +1,6 @@
 class UserMailer < ApplicationMailer
+  def welcome_email(user)
+    @user = user
+    mail(to: @user.email, subject: "【 Memory. 】会員登録完了")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable # email再設定時の認証メール送信
 
   validates :name, presence: true, length: { maximum: 30 }
   has_many :albums, dependent: :destroy

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full flex flex-col items-center">
   <h1 class="text-2xl font-bold md:text-3xl mb-10 text-gray-800"><%= t('.title') %></h1>
 
-  <div class="px-6 mb-7 xl:w-2/3 w-full overflow-x-auto">
+  <div class="px-6 mb-7 w-full overflow-x-auto">
     <% if @users.present? %>
       <table class="min-w-full bg-white border border-gray-200">
         <thead>
@@ -19,7 +19,7 @@
               <td class="py-3 px-6 text-left whitespace-nowrap"><%= user.email %></td>
               <td class="py-3 px-6 text-left whitespace-nowrap"><%= user.created_at.strftime("%Y年%m月%d日 %H:%M") %></td>
               <td class="py-3 px-6 text-center">
-                <div class="flex whitespace-nowrap space-x-2">
+                <div class="flex whitespace-nowrap space-x-2 justify-center">
                   <%= link_to t('.detail'), admins_user_path(user), class: "inline-block bg-orange-500 hover:bg-orange-600 text-white text-xs font-semibold py-2 px-4 rounded" %>
                   <%= link_to t('.edit'), edit_admins_user_path(user), class: "inline-block bg-green-500 hover:bg-green-600 text-white text-xs font-semibold py-2 px-4 rounded" %>
                   <%= link_to t('.delete'), admins_user_path(user), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: "inline-block bg-red-500 hover:bg-red-600 text-white text-xs font-semibold py-2 px-4 rounded" %>

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -4,8 +4,8 @@
   <div class="space-y-4 text-gray-700 text-base">
     <p><strong><%= t('.name') %>：</strong> <%= @user.name %></p>
     <p><strong><%= t('.email') %>：</strong> <%= @user.email %></p>
-    <p><strong><%= t('.albums.count') %>：</strong> <%= @user.albums.count %></p>
-    <p><strong><%= t('.photos.count') %>：</strong> <%= @user.photos.count %></p>
+    <p><strong><%= t('.albums_count') %>：</strong> <%= @user.albums.count %></p>
+    <p><strong><%= t('.photos_count') %>：</strong> <%= @user.photos.count %></p>
     <p><strong><%= t('.albums_last_created_at') %>：</strong>
       <% if @user.albums.any? %>
         <%= l @user.albums.last.created_at, format: :default %></p>

--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -1,0 +1,8 @@
+<p>こんにちは、<%= @user.name %>さん！</p>
+
+<p>この度は【 Memory. 】アプリをご利用頂きありがとうございます。</p>
+
+<p>会員登録が完了しました。</p>
+
+<p>下記URLより、ログインしていただけます。</p>
+<p>https://memory-20250515.onrender.com/users/sign_in</p>

--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -1,8 +1,7 @@
-<p>こんにちは、<%= @user.name %>さん！</p>
+<p><%= t('users.user_mailer.welcome_email.greeting', name: @user.name) %></p>
 
-<p>この度は【 Memory. 】アプリをご利用頂きありがとうございます。</p>
+<p><%= t('users.user_mailer.welcome_email.thank_you') %></p>
 
-<p>会員登録が完了しました。</p>
+<p><%= t('users.user_mailer.welcome_email.completed_registration') %></p>
 
-<p>下記URLより、ログインしていただけます。</p>
-<p>https://memory-20250515.onrender.com/users/sign_in</p>
+<p><%= link_to t('users.user_mailer.welcome_email.login_instruction'), "https://memory-20250515.onrender.com/users/sign_in" %></p>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <div class='w-full flex flex-col items-center'>
   <div class='font-semibold text-2xl md:text-3xl mb-6 text-gray-800'>
-    Resend confirmation instructions
+    <%= t('devise.confirmations.new.resend_confirmation_instructions') %>
   </div>
   
   <div class='rounded-lg w-full max-w-xl p-8 justify-center'>
@@ -13,7 +13,7 @@
       </div>
     
       <div class="mt-6 flex justify-center">
-        <%= f.submit "Resend confirmation instructions", class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
+        <%= f.submit t('devise.confirmations.new.resend_confirmation_instructions1'), class: "w-full bg-button text-white mt-4 mx-20 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,16 +1,20 @@
-<h2>Resend confirmation instructions</h2>
-
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+<div class='w-full flex flex-col items-center'>
+  <div class='font-semibold text-2xl md:text-3xl mb-6 text-gray-800'>
+    Resend confirmation instructions
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+  
+  <div class='rounded-lg w-full max-w-xl p-8 justify-center'>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+    
+      <div class="mb-6 flex items-center">
+        <%= f.label :email, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <div class="mt-6 flex justify-center">
+        <%= f.submit "Resend confirmation instructions", class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
+      </div>
+    <% end %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('devise.mailer.confirmation_instructions.greeting', recipient: @resource.name) %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('devise.mailer.confirmation_instructions.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('devise.mailer.confirmation_instructions.confirm_account'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/email_changed.html.erb
+++ b/app/views/users/mailer/email_changed.html.erb
@@ -1,3 +1,4 @@
+<!-- メールアドレスが即時変更された場合, config.reconfirmable = falseの時に通知メールとして使用される-->
 <p>Hello <%= @email %>!</p>
 
 <% if @resource.try(:unconfirmed_email?) %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -151,7 +151,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 1.minute
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -151,7 +151,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 1.minute
+  config.confirm_within = 3.day
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -161,6 +161,7 @@ ja:
       confirmation: と一致しません。
       too_short: は%{count}文字以上で入力してください。
       invalid: は無効です。確認メールのリンクが間違っているか、有効期限が切れている可能性があります。
+      taken: は既に使用されています。
   datetime:
     distance_in_words:
       x_minutes:

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -53,9 +53,10 @@ ja:
     mailer:
       confirmation_instructions:
         action: メールアドレスの確認
-        greeting: "%{recipient}様"
-        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
+        greeting: "こんにちは、%{recipient}さん"
+        instruction: 72時間以内に以下のリンクをクリックし、メールアドレスの変更手続を完了させてください。
+        subject: 【 Memory. 】メールアドレス変更確認
+        confirm_account: メールアドレスを変更する
       email_changed:
         greeting: こんにちは、%{recipient}様。
         message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -38,6 +38,7 @@ ja:
       confirmed: メールアドレスが確認できました。
       new:
         resend_confirmation_instructions: アカウント確認メール再送
+        resend_confirmation_instructions1: アカウント確認メールを再送する
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
@@ -55,7 +56,7 @@ ja:
         action: メールアドレスの確認
         greeting: "こんにちは、%{recipient}さん"
         instruction: 72時間以内に以下のリンクをクリックし、メールアドレスの変更手続を完了させてください。
-        subject: 【 Memory. 】メールアドレス変更確認
+        subject: 【 Memory. 】メールアドレス変更手続き
         confirm_account: メールアドレスを変更する
       email_changed:
         greeting: こんにちは、%{recipient}様。

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -2,22 +2,22 @@ ja:
   activerecord:
     attributes:
       user:
-        name: 名前：
+        name: 名前
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻
         created_at: 作成日
-        current_password: 現在のパスワード：
+        current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: メールアドレス：
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
-        password: パスワード：
-        password_confirmation: パスワード（確認用）：
+        password: パスワード
+        password_confirmation: パスワード（確認用）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻
@@ -27,9 +27,9 @@ ja:
         unlock_token: ロック解除用トークン
         updated_at: 更新日
       admin:
-        email: メールアドレス：
-        password: パスワード：
-        password_confirmation: パスワード（確認用）：
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認用）
     models:
       user: ユーザー
       admin: 管理者
@@ -150,7 +150,7 @@ ja:
   errors:
     messages:
       already_confirmed: は既に登録済みです。ログインしてください。
-      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      confirmation_period_expired: の期限が切れました。%{period} 以内に確認する必要があります。 新しくリクエストしてください。
       expired: の有効期限が切れました。新しくリクエストしてください。
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
@@ -159,3 +159,8 @@ ja:
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
       confirmation: と一致しません。
       too_short: は%{count}文字以上で入力してください。
+  datetime:
+    distance_in_words:
+      x_minutes:
+        one: 1分
+        other: "%{count}分"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -159,6 +159,7 @@ ja:
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
       confirmation: と一致しません。
       too_short: は%{count}文字以上で入力してください。
+      invalid: は無効です。確認メールのリンクが間違っているか、有効期限が切れている可能性があります。
   datetime:
     distance_in_words:
       x_minutes:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -79,6 +79,13 @@ ja:
         photos_count: 全画像数
         albums_last_created_at: 最終アルバム作成日時
         back: 一覧に戻る
+  users:
+    user_mailer:
+      welcome_email:
+        greeting: "こんにちは、%{name}さん！"
+        thank_you: この度は【 Memory. 】アプリをご利用頂きありがとうございます。
+        completed_registration: 会員登録が完了しました。
+        login_instruction: ログインはこちら
 
   errors:
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: "users/sessions",
     registrations: "users/registrations",
-    passwords: "users/passwords"
+    passwords: "users/passwords",
+    confirmations: "users/confirmations"
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250604211936_add_column_to_users.rb
+++ b/db/migrate/20250604211936_add_column_to_users.rb
@@ -1,0 +1,8 @@
+class AddColumnToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :confirmation_token,   :string
+    add_column :users, :confirmed_at,         :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email,      :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_29_005225) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_04_211936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_005225) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,8 @@
   User.create!(name: Faker::Name.name,
               email: Faker::Internet.unique.email,
               password: "password",
-              password_confirmation: "password")
+              password_confirmation: "password",
+              confirmed_at: Time.current)
 end
 
 user_ids = User.ids


### PR DESCRIPTION
## 概要
ユーザーのメール認証機能追加

## 詳細
メール認証について下記の設定で追加
  - 会員登録時　　　　　　　　　　：welcomeメール送信（メール認証なし）
  - 既存会員のメールアドレス変更時：メール認証あり
  
 会員情報編集後は会員情報編集画面に設定

Closes #56 