### PR TITLE
ブランチ：27 admin edit registration

### DIFF
--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -18,7 +18,7 @@
       </div>
     
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <div class='text-orange-600 font-semibold text-center md:text-lg mb-4'><%= t('devise.registrations.edit.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
       <% end %>
 
       <div class="mb-6 flex items-center">
@@ -41,6 +41,6 @@
       </div>
     <% end %>
 
-    <div class="mt-6 flex justify-center"><%= link_to t('devise.shared.links.back'), :back %></div>
+    <div class="mt-6 flex justify-center text-gray-700"><%= link_to t('devise.shared.links.back'), admins_dashboards_path %></div>
   </div>
 </div>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="w-full flex flex-col items-center">
-  <div class="font-semibold text-2xl md:text-3xl mb-2 text-gray-800">
+  <div class="font-semibold text-2xl md:text-3xl text-gray-800">
     <%= t('devise.registrations.edit.title_admin') %>
   </div>
   

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="w-full flex flex-col items-center">
-  <div class="font-semibold text-2xl md:text-3xl mb-6 text-gray-800">
+  <div class="font-semibold text-2xl md:text-3xl mb-2 text-gray-800">
     <%= t('devise.registrations.edit.title_admin') %>
   </div>
   
@@ -7,10 +7,10 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "admins/shared/error_messages", resource: resource %>
     
-      <p class="w-full text-gray-700 text-sm ml-8 mb-6 md:whitespace-nowrap">
-        ※ パスワードを変更しない場合、「パスワード」「パスワード（確認）」の項目は空欄にしてください。<br>
-        ※ <%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %>
-      </p>
+      <div class="w-full text-gray-700 text-sm ml-8 md:whitespace-nowrap">
+        <div class="mb-2">※ <%= t('devise.registrations.edit.leave_password_and_password_confirmation_blank_if_you_don\'t_want_to_change_them') %></div>
+        <div class='mb-6'>※ <%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %></div>
+      </div>
 
       <div class="mb-6 flex items-center">
         <%= f.label :email, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,43 +1,46 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="w-full flex flex-col items-center">
+  <div class="font-semibold text-2xl md:text-3xl mb-6 text-gray-800">
+    <%= t('devise.registrations.edit.title_admin') %>
   </div>
+  
+  <div class='rounded-lg w-full max-w-xl p-8 justify-center'>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "admins/shared/error_messages", resource: resource %>
+    
+      <p class="w-full text-gray-700 text-sm ml-8 mb-6 md:whitespace-nowrap">
+        ※ パスワードを変更しない場合、「パスワード」「パスワード（確認）」の項目は空欄にしてください。<br>
+        ※ <%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %>
+      </p>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <div class="mb-6 flex items-center">
+        <%= f.label :email, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="mb-6 flex items-center">
+        <%= f.label :password, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
+        <%= f.password_field :password, autocomplete: "new-password", class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <div class="mb-6 flex items-center">
+        <%= f.label :password_confirmation, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %><br />
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <div class="mb-6 flex items-center">
+        <%= f.label :current_password, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
+        <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+    
+      <div class="mt-6 flex justify-center">
+        <%= f.submit t('devise.registrations.edit.update'), class: "w-1/3 bg-pink-500 text-white mt-4 py-2 rounded-md font-semibold hover:bg-pink-600 text-md md:text-lg" %>
+      </div>
     <% end %>
+
+    <div class="mt-6 flex justify-center"><%= link_to t('devise.shared.links.back'), :back %></div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/admins/shared/_header.html.erb
+++ b/app/views/admins/shared/_header.html.erb
@@ -20,7 +20,7 @@
               </button>
               <div id="js-dropdown" class="absolute right-0 mt-2 w-65 bg-white rounded shadow-lg py-2 z-10 hidden text-gray-800">
                 <div class="block px-4 py-2 text-blue-900 font-bold underline"><%= current_admin.email %> </div>
-                  <%= link_to t('header.account'), "#", class: "block px-4 py-2 hover:bg-gray-100" %>
+                  <%= link_to t('header.account'), edit_admin_registration_path, class: "block px-4 py-2 hover:bg-gray-100" %>
                   <%= button_to t('header.logout'), destroy_admin_session_path, method: :delete, form: { data: { turbo: false } }, class: "block w-full text-left px-4 py-2 hover:bg-gray-100" %>
                 </div>
               </div>

--- a/app/views/admins/shared/_header.html.erb
+++ b/app/views/admins/shared/_header.html.erb
@@ -1,7 +1,7 @@
     <% if admin_signed_in? %>
       <div class="w-full bg-pink-700 h-28 flex flex-col justify-end">
-        <div class="text-white border border-white rounded-lg font-bold text-lg px-2 w-1/12 ml-16">
-          <p class="ml-6"><%= t('admins.header.admin') %></p>
+        <div class="text-white border border-white rounded-lg font-bold text-lg px-2 w-1/6 ml-4 md:w-1/12 md:ml-16">
+          <p class="ml-6 flex whitespace-nowrap"><%= t('admins.header.admin') %></p>
         </div>
         <div class="flex justify-between items-end px-4 md:px-16 pb-4">
           <!-- ロゴとタイトル -->

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -11,7 +11,7 @@
 
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+        <div class='text-orange-500 font-semibold text-center md:text-lg mb-4'><%= t('devise.registrations.edit.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
       <% end %>
 
       <div class="w-full text-gray-700 text-sm ml-8 md:whitespace-nowrap">
@@ -49,6 +49,6 @@
       </div>
     <% end %>
 
-    <div class="mt-6 flex justify-center"><%= link_to t('devise.shared.links.back'), :back %></div>
+    <div class="mt-6 flex justify-center text-gray-700"><%= link_to t('devise.shared.links.back'), albums_path %></div>
   </div>
 </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -11,7 +11,7 @@
 
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div class='text-orange-500 font-semibold text-center md:text-lg mb-4'><%= t('devise.registrations.edit.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+        <div class='text-green-600 font-semibold text-center md:text-lg mb-4'><%= t('devise.registrations.edit.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
       <% end %>
 
       <div class="w-full text-gray-700 text-sm ml-8 md:whitespace-nowrap">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -9,9 +9,15 @@
 
       <%= render "users/shared/error_messages", resource: resource %>
 
+
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
+
+      <div class="w-full text-gray-700 text-sm ml-8 md:whitespace-nowrap">
+        <div class="mb-2">※ <%= t('devise.registrations.edit.leave_password_and_password_confirmation_blank_if_you_don\'t_want_to_change_them') %></div>
+        <div class='mb-6'>※ <%= t('devise.registrations.edit.we_need_your_current_password_to_confirm_your_changes') %></div>
+      </div>
 
       <div class="mb-6 flex items-center">
         <%= f.label :name, class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
@@ -42,5 +48,7 @@
         <%= f.submit t('defaults.update'), class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
       </div>
     <% end %>
+
+    <div class="mt-6 flex justify-center"><%= link_to t('devise.shared.links.back'), :back %></div>
   </div>
 </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="w-full flex flex-col items-center">
-  <div class="font-semibold text-2xl md:text-3xl mb-6 text-gray-800">
+  <div class="font-semibold text-2xl md:text-3xl text-gray-800">
     <%= t('devise.registrations.edit.title') %>
   </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -151,7 +151,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 3.day
+  config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -17,7 +17,7 @@ ja:
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
         password: パスワード
-        password_confirmation: パスワード（確認用）
+        password_confirmation: パスワード（確認）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻
@@ -29,7 +29,8 @@ ja:
       admin:
         email: メールアドレス
         password: パスワード
-        password_confirmation: パスワード（確認用）
+        password_confirmation: パスワード（確認）
+        current_password: 現在のパスワード
     models:
       user: ユーザー
       admin: 管理者
@@ -109,6 +110,7 @@ ja:
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
         title: 会員情報編集
+        title_admin: 管理者情報編集
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -113,7 +113,8 @@ ja:
         title_admin: 管理者情報編集
         unhappy: 気に入りません
         update: 更新
-        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには「現在のパスワード」の項目を入力してください。
+        leave_password_and_password_confirmation_blank_if_you_don't_want_to_change_them: パスワードを変更しない場合、「パスワード」「パスワード（確認）」の項目は空欄にしてください。
       new:
         title: 会員登録
         admin_title: 管理者アカウント作成


### PR DESCRIPTION
## 概要
- 管理者情報編集画面の作成
- ユーザーと管理者のメール認証待ちのメッセージのレイアウト修正
- その他軽微な修正

## 詳細
- 管理者情報編集画面のレイアウト追加
- メール認証待ちの時に表示されるメッセージの日本語化
- 会員情報編集ページの「戻る」リンクの遷移先→アルバム一覧
- 管理者情報編集ページの「戻る」リンクの遷移先→ダッシュボード
- 管理者用レイアウトについて、画面サイズが小さくなった時のヘッダーのレイアウトの崩れを修正

Closes #44 
