### PR TITLE
ブランチ: 28_render_error

### DIFF
--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -41,6 +41,6 @@
       </div>
     <% end %>
 
-    <div class="mt-6 flex justify-center text-gray-700"><%= link_to t('devise.shared.links.back'), admins_dashboards_path %></div>
+    <div class="mt-6 flex justify-center text-gray-700"><%= link_to t('devise.shared.links.back'), admins_dashboard_path %></div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
Renderエラー対処

## 詳細
管理者情報編集ページの戻るリンクのパスをadmins_dashborad_pathに修正